### PR TITLE
feat: 내 이용권 리스트 조회 기능 추가

### DIFF
--- a/hobbyloop-api/src/main/java/hobbyloop/backend/api/applicationservice/ticket/TicketApplicationService.java
+++ b/hobbyloop-api/src/main/java/hobbyloop/backend/api/applicationservice/ticket/TicketApplicationService.java
@@ -1,12 +1,31 @@
 package hobbyloop.backend.api.applicationservice.ticket;
 
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Service;
 
+import hobbyloop.backend.api.controller.ticket.UserTicketInfoListResponseDTO;
 import hobbyloop.backend.domain.ticket.TicketService;
+import hobbyloop.backend.domain.ticket.UserTicket;
+import hobbyloop.backend.domain.ticket.UserTicketService;
+import hobbyloop.backend.domain.user.UserService;
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class TicketApplicationService {
+	private final UserService userService;
 	private final TicketService ticketService;
+	private final UserTicketService userTicketService;
+
+	public List<UserTicketInfoListResponseDTO> getUserTicketInfoListByUser(String username) {
+		Map<String, List<UserTicket>> userTicketsGroupByCenter =
+			userTicketService.getUserTicketsGroupByCenter(userService.getUserByUsername(username));
+
+		return userTicketsGroupByCenter.keySet().stream()
+			.map(key -> UserTicketInfoListResponseDTO.from(key, userTicketsGroupByCenter.get(key)))
+			.collect(Collectors.toList());
+	}
 }

--- a/hobbyloop-api/src/main/java/hobbyloop/backend/api/controller/center/CenterController.java
+++ b/hobbyloop-api/src/main/java/hobbyloop/backend/api/controller/center/CenterController.java
@@ -5,7 +5,6 @@ import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/hobbyloop-api/src/main/java/hobbyloop/backend/api/controller/ticket/TicketController.java
+++ b/hobbyloop-api/src/main/java/hobbyloop/backend/api/controller/ticket/TicketController.java
@@ -1,11 +1,19 @@
 package hobbyloop.backend.api.controller.ticket;
 
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import hobbyloop.backend.api.applicationservice.ticket.TicketApplicationService;
+import hobbyloop.backend.api.infra.global.oauth2.OAuth2UserDetails;
+import hobbyloop.backend.api.infra.util.ApiResponse;
 import io.swagger.annotations.Api;
 import lombok.RequiredArgsConstructor;
+import springfox.documentation.annotations.ApiIgnore;
 
 @Api(tags = {"이용권 API 정보를 제공하는 Controller 입니다."})
 @RestController
@@ -14,4 +22,12 @@ import lombok.RequiredArgsConstructor;
 public class TicketController {
 
 	private final TicketApplicationService ticketApplicationService;
+
+	@GetMapping("/list")
+	public ApiResponse<List<UserTicketInfoListResponseDTO>> getUserTicketInfoList(
+		@ApiIgnore @AuthenticationPrincipal OAuth2UserDetails userDetails
+	) {
+		return ApiResponse.success(HttpStatus.OK,
+			ticketApplicationService.getUserTicketInfoListByUser(userDetails.getUsername()));
+	}
 }

--- a/hobbyloop-api/src/main/java/hobbyloop/backend/api/controller/ticket/TicketController.java
+++ b/hobbyloop-api/src/main/java/hobbyloop/backend/api/controller/ticket/TicketController.java
@@ -12,6 +12,7 @@ import hobbyloop.backend.api.applicationservice.ticket.TicketApplicationService;
 import hobbyloop.backend.api.infra.global.oauth2.OAuth2UserDetails;
 import hobbyloop.backend.api.infra.util.ApiResponse;
 import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import springfox.documentation.annotations.ApiIgnore;
 
@@ -23,6 +24,7 @@ public class TicketController {
 
 	private final TicketApplicationService ticketApplicationService;
 
+	@ApiOperation(value = "자신의 이용권 리스트 조회", notes = "회원용 유저가 자신의 이용권 리스트를 조회하는 요청입니다.")
 	@GetMapping("/list")
 	public ApiResponse<List<UserTicketInfoListResponseDTO>> getUserTicketInfoList(
 		@ApiIgnore @AuthenticationPrincipal OAuth2UserDetails userDetails

--- a/hobbyloop-api/src/main/java/hobbyloop/backend/api/controller/ticket/UserTicketInfoListResponseDTO.java
+++ b/hobbyloop-api/src/main/java/hobbyloop/backend/api/controller/ticket/UserTicketInfoListResponseDTO.java
@@ -1,0 +1,28 @@
+package hobbyloop.backend.api.controller.ticket;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import hobbyloop.backend.domain.ticket.UserTicket;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class UserTicketInfoListResponseDTO {
+	private String centerName;
+	private List<UserTicketInfoResponseDTO> ticketInfos;
+
+	public static UserTicketInfoListResponseDTO from(String centerName, List<UserTicket> userTickets) {
+
+		return UserTicketInfoListResponseDTO.builder()
+			.centerName(centerName)
+			.ticketInfos(userTickets.stream().map(UserTicketInfoResponseDTO::from).collect(Collectors.toList()))
+			.build();
+	}
+}

--- a/hobbyloop-api/src/main/java/hobbyloop/backend/api/controller/ticket/UserTicketInfoListResponseDTO.java
+++ b/hobbyloop-api/src/main/java/hobbyloop/backend/api/controller/ticket/UserTicketInfoListResponseDTO.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import hobbyloop.backend.domain.ticket.UserTicket;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,7 +16,10 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class UserTicketInfoListResponseDTO {
+	@ApiModelProperty(name = "센터명", example = "에이블짐 1호점")
 	private String centerName;
+
+	@ApiModelProperty(name = "사용자의 티켓 정보 List")
 	private List<UserTicketInfoResponseDTO> ticketInfos;
 
 	public static UserTicketInfoListResponseDTO from(String centerName, List<UserTicket> userTickets) {

--- a/hobbyloop-api/src/main/java/hobbyloop/backend/api/controller/ticket/UserTicketInfoListResponseDTO.java
+++ b/hobbyloop-api/src/main/java/hobbyloop/backend/api/controller/ticket/UserTicketInfoListResponseDTO.java
@@ -19,10 +19,14 @@ public class UserTicketInfoListResponseDTO {
 	private List<UserTicketInfoResponseDTO> ticketInfos;
 
 	public static UserTicketInfoListResponseDTO from(String centerName, List<UserTicket> userTickets) {
+		List<UserTicketInfoResponseDTO> userTicketInfoFromUserTicket =
+			userTickets.stream()
+				.map(UserTicketInfoResponseDTO::from)
+				.collect(Collectors.toList());
 
 		return UserTicketInfoListResponseDTO.builder()
 			.centerName(centerName)
-			.ticketInfos(userTickets.stream().map(UserTicketInfoResponseDTO::from).collect(Collectors.toList()))
+			.ticketInfos(userTicketInfoFromUserTicket)
 			.build();
 	}
 }

--- a/hobbyloop-api/src/main/java/hobbyloop/backend/api/controller/ticket/UserTicketInfoResponseDTO.java
+++ b/hobbyloop-api/src/main/java/hobbyloop/backend/api/controller/ticket/UserTicketInfoResponseDTO.java
@@ -1,0 +1,29 @@
+package hobbyloop.backend.api.controller.ticket;
+
+import java.time.LocalDate;
+
+import hobbyloop.backend.domain.ticket.UserTicket;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class UserTicketInfoResponseDTO {
+	private String ticketImageUrl;
+	private String ticketName;
+	private LocalDate startDate;
+	private LocalDate endDate;
+
+	public static UserTicketInfoResponseDTO from(UserTicket userTicket) {
+		return UserTicketInfoResponseDTO.builder()
+			.ticketImageUrl(userTicket.getTicket().getTicketImageUrl())
+			.ticketName(userTicket.getTicket().getTicketName())
+			.startDate(userTicket.getStartDate())
+			.endDate(userTicket.getEndDate()).build();
+	}
+}

--- a/hobbyloop-api/src/main/java/hobbyloop/backend/api/controller/ticket/UserTicketInfoResponseDTO.java
+++ b/hobbyloop-api/src/main/java/hobbyloop/backend/api/controller/ticket/UserTicketInfoResponseDTO.java
@@ -3,6 +3,7 @@ package hobbyloop.backend.api.controller.ticket;
 import java.time.LocalDate;
 
 import hobbyloop.backend.domain.ticket.UserTicket;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -14,9 +15,16 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class UserTicketInfoResponseDTO {
+	@ApiModelProperty(name = "이용권 이미지 url")
 	private String ticketImageUrl;
+
+	@ApiModelProperty(name = "이용권 명", example = "6대1 필라테스 수업")
 	private String ticketName;
+
+	@ApiModelProperty(name = "이용권 기간 시작 날짜", example = "2023-06-20")
 	private LocalDate startDate;
+
+	@ApiModelProperty(name = "이용권 기간 끝 날짜", example = "2023-08-30")
 	private LocalDate endDate;
 
 	public static UserTicketInfoResponseDTO from(UserTicket userTicket) {

--- a/hobbyloop-api/src/main/java/hobbyloop/backend/api/controller/userprofile/dto/UserTicketInfoDTO.java
+++ b/hobbyloop-api/src/main/java/hobbyloop/backend/api/controller/userprofile/dto/UserTicketInfoDTO.java
@@ -17,6 +17,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserTicketInfoDTO {
+	@ApiModelProperty(name = "이용권 이미지")
+	private String ticketImageUrl;
+
 	@ApiModelProperty(name = "업체명", example = "에이블짐 창신점")
 	private String centerName;
 
@@ -28,7 +31,8 @@ public class UserTicketInfoDTO {
 
 	public static UserTicketInfoDTO from(UserTicket userTicket) {
 		return UserTicketInfoDTO.builder()
-			.centerName(userTicket.getCenter().getCenterName())
+			.ticketImageUrl(userTicket.getTicket().getTicketImageUrl())
+			.centerName(userTicket.getTicket().getCenter().getCenterName())
 			.remainingCounts(userTicket.getRemainingCounts())
 			.endDate(userTicket.getEndDate())
 			.build();

--- a/hobbyloop-domain/src/main/java/hobbyloop/backend/domain/ticket/Ticket.java
+++ b/hobbyloop-domain/src/main/java/hobbyloop/backend/domain/ticket/Ticket.java
@@ -32,9 +32,15 @@ public class Ticket extends BaseTime {
 	@Enumerated(value = EnumType.STRING)
 	private TicketType ticketType;
 
-	private String keyword;
+	private String ticketName;
+
+	private String ticketImageUrl;
+
 	private int price;
+
 	private int days;
+
 	private int salesAmount;
+
 	private double score;
 }

--- a/hobbyloop-domain/src/main/java/hobbyloop/backend/domain/ticket/UserTicket.java
+++ b/hobbyloop-domain/src/main/java/hobbyloop/backend/domain/ticket/UserTicket.java
@@ -10,7 +10,6 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 
 import hobbyloop.backend.domain.BaseTime;
-import hobbyloop.backend.domain.center.Center;
 import hobbyloop.backend.domain.user.User;
 import lombok.Getter;
 
@@ -27,15 +26,14 @@ public class UserTicket extends BaseTime {
 	private Ticket ticket;
 
 	@ManyToOne
-	@JoinColumn(name = "centerId")
-	private Center center;
-
-	@ManyToOne
 	@JoinColumn(name = "userId")
 	private User user;
 
 	private LocalDate startDate;
+
 	private LocalDate endDate;
+
 	private int remainingDays;
+
 	private int remainingCounts;
 }

--- a/hobbyloop-domain/src/main/java/hobbyloop/backend/domain/ticket/UserTicketService.java
+++ b/hobbyloop-domain/src/main/java/hobbyloop/backend/domain/ticket/UserTicketService.java
@@ -1,6 +1,9 @@
 package hobbyloop.backend.domain.ticket;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,7 +18,24 @@ public class UserTicketService {
 
 	private final UserTicketRepository userTicketRepository;
 
+	public Map<String, List<UserTicket>> getUserTicketsGroupByCenter(User user) {
+		List<UserTicket> allByUser = findAllUserTicketsByUser(user);
+		Map<String, List<UserTicket>> userTicketMap = new HashMap<>();
+		for (UserTicket userTicket : allByUser) {
+			String centerName = userTicket.getTicket().getCenter().getCenterName();
+			if (userTicketMap.containsKey(centerName)) {
+				userTicketMap.get(centerName).add(userTicket);
+			} else {
+				List<UserTicket> userTicketsOfCenter = new ArrayList<>();
+				userTicketsOfCenter.add(userTicket);
+				userTicketMap.put(centerName, userTicketsOfCenter);
+			}
+		}
+		return userTicketMap;
+	}
+
 	public List<UserTicket> findAllUserTicketsByUser(User user) {
 		return userTicketRepository.findAllByUser(user);
 	}
+
 }


### PR DESCRIPTION
https://github.com/hobbyloop/hobbyloop-be/issues/80

+ ticket 대표 이미지 칼럼 추가
+ userTicket 과 Ticket 은 api 모듈 에서는 동일한 도메인에서 관리, domain 에서는 분리된 도메인으로 관리

